### PR TITLE
Add first party tracking using umami.is

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -74,6 +74,12 @@
 
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 
+    <!-- Umami first-party tracking on http://tracking.guitton.co/ -->
+    <script async defer
+      src="http://tracking.guitton.co/umami.js"
+      data-website-id="15682e3c-69f9-4b4a-98eb-3805754f832b"
+      data-do-not-track="true"
+    ></script>
   </head>
 
   <body class="{{ if .Site.Params.rtl }}rtl{{ end }} {{ if .Site.Params.inverted }}inverted{{ end }}">

--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -1,0 +1,27 @@
+<section class="container centered">
+    <div class="about">
+      {{ with .Site.Params.avatarurl }}
+        <div class="avatar"><img src="{{ . | relURL }}" alt="avatar"></div>
+      {{ end }}
+      <h1>{{ .Site.Params.author }}</h1>
+      <h2>{{ .Site.Params.info }}</h2>
+
+      {{ with .Site.Params.social }}
+      <ul>
+        {{ range sort .}}
+          {{ if .icon }}
+            <li>
+              <a href="{{ .url }}" aria-label="{{ .name }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} {{ if .target }}target="{{ .target }}"{{ end }} onclick="umami.trackEvent('{{ .name }}-clicked', 'click')">
+                <i class="{{ .icon }}" aria-hidden="true"></i>
+              </a>
+            </li>
+          {{ else }}
+            <li>
+              <a href="{{ .url }}" aria-label="{{ .name }}" {{ if .rel }}rel="{{ .rel }}"{{ end }} {{ if .target }}target="{{ .target }}"{{ end }} onclick="umami.trackEvent('{{ .name }}-clicked', 'click')">{{ .name }}</a>
+            </li>
+          {{ end }}
+        {{ end }}
+      </ul>
+      {{ end }}
+    </div>
+  </section>


### PR DESCRIPTION
Lately, there's a been a couple really interesting first-party tracking tools that have emerged for the web:
- https://plausible.io/  (SaaS)
- https://umami.is/  (open source, you can deploy your own)

In this PR, I add first party tracking to my website using umami.
- I deployed the webserver and the database using Heroku (see https://dashboard.heroku.com/apps/umami-tracking).
- I had to push a small hotfix to my fork due to Heroku's port allocation https://github.com/louisguitton/umami/pull/1
- I set up the custom DNS on Heroku to have it under tracking.guitton.co (my DNS provider for guitton.co is Netlify not Digital Ocean)
- Data is flowing, see the dashboard here http://tracking.guitton.co/share/9biyXQlW/guitton.co

If I'm satisfied with it (it looks great already, but I'm just wondering what happens when Heroku goes to sleep), I will sunset Google Analytics tracking from my website.

