### PR TITLE
Add structured data to my site for advanced SEO

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,6 +45,9 @@ googleAnalytics = "UA-140255752-1"
     math = true
     custom_css = []
 
+    # for schema.org
+    publisher_name = "Guitton.co"
+
 # Social links
 [[params.social]]
     name = "Github"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,6 +12,8 @@
 
     {{ template "_internal/twitter_cards.html" . }}
     {{ template "_internal/opengraph.html" . }}
+    {{/*  schema.org  */}}
+    {{ partial "schema.html" . }}
 
     {{ if .Permalink }}
       <base href="{{ .Permalink }}">

--- a/layouts/partials/schema.html
+++ b/layouts/partials/schema.html
@@ -1,0 +1,39 @@
+{{/*  https://dev.to/pdwarkanath/adding-structured-data-to-your-hugo-site-58db  */}}
+{{/*  https://developers.google.com/search/docs/data-types/article  */}}
+{{/*  https://search.google.com/test/rich-results  */}}
+{{ if eq .Section "posts" }}
+<script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "BlogPosting",
+        "headline": {{ .Title }},
+        "image": {{ .Params.featuredImage | absURL }},
+        "datePublished": {{ .PublishDate }},
+        "dateModified": {{ .Lastmod }},
+        "author": {
+            "@type": "Person",
+            "name": {{ .Site.Params.author }}
+        },
+        "mainEntityOfPage": { "@type": "WebPage" },
+        "publisher": {
+            "@type": "Organization",
+            "name": {{ .Site.Params.publisher_name }},
+            "logo": {
+                "@type": "ImageObject",
+                "url": {{ .Site.Params.avatarurl | absURL  }}
+            }
+        },
+        "description": {{ .Summary | plainify | safeHTML }},
+        "keywords": [{{ range $i, $e := .Keywords }}{{ if $i }}, {{ end }}{{ $e }}{{ end }}]
+    }
+</script>
+{{ end }}
+<script type="application/ld+json">
+{
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": {{ .Site.Params.publisher_name }},
+    "url": {{ .Site.BaseURL }},
+    "sameAs": [{{ range $i, $e := .Site.Params.Social }}{{ if $i }}, {{ end }}{{ $e.url }}{{ end }}]
+}
+</script>


### PR DESCRIPTION
For all non-post pages : 
![image](https://user-images.githubusercontent.com/7823843/99146653-6b1f2180-267a-11eb-8f8a-bf5156e1441c.png)

For post pages : 
![image](https://user-images.githubusercontent.com/7823843/99146668-90139480-267a-11eb-9bb7-e2951703030b.png)
![image](https://user-images.githubusercontent.com/7823843/99146674-9a359300-267a-11eb-9595-0416d57521c5.png)

Reference:
  - https://developers.google.com/search/docs/data-types/article
  - https://search.google.com/test/rich-results
  - https://dev.to/pdwarkanath/adding-structured-data-to-your-hugo-site-58db